### PR TITLE
added option to package to a directory instead of a disk image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,12 @@ build/full1200.img: assets build/px3_ose.com
 	$(foreach file,$(SOUND),$(MCOPYOPTS) mcopy -i $@ build/assets/$(file) ::$(file);)
 	$(foreach file,$(MUSIC_MIDI),$(MCOPYOPTS) mcopy -i $@ build/assets/$(file) ::$(file);)
 
+build/release: assets build/px3_ose.com
+	mkdir -p build/release/
+	cp build/assets/* build/release/
+	cp assets/maplist.bin build/release/
+	cp build/px3_ose.com build/release/
+
 .PHONY: clean dosbox_vga dosbox_cga dosbox_tandy dosbox_hercules
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,7 @@ clean:
 	rm build/assets/*.cgt
 	rm build/assets/*.cmp
 	rm build/assets/*.vga
+	rm -r build/release
 
 dosbox_vga: px3_full
 	dosbox -conf dosbox/vga.conf


### PR DESCRIPTION
I added an option to Makefile to allow making an release to directory instead of a disk (`make px3_full` puts assets in `assets` directory thus making Planet X3 unable to start if DOSBox is run from `build` directory instead of the disk images)

```
build/release: assets build/px3_ose.com
	mkdir -p build/release/
	cp build/assets/* build/release/
	cp assets/maplist.bin build/release/
	cp build/px3_ose.com build/release/
```